### PR TITLE
Fix broken attribute XML if attribute value contains double quote character.

### DIFF
--- a/src/XmlBeautify.js
+++ b/src/XmlBeautify.js
@@ -180,7 +180,7 @@ export default class XmlBeautify {
     //add attributes
     for (let i = 0; i < element.attributes.length; i++) {
       const attr = element.attributes[i];
-      buildInfo.xmlText += ' ' + attr.name + '=' + '"' + attr.textContent + '"';
+      buildInfo.xmlText += ' ' + attr.name + '=' + '"' + attr.textContent.replace(/"/g, "&quot;") + '"';
     }
 
     if (isEmptyElement && useSelfClosingElement) {

--- a/test/XmlBeautify.test.js
+++ b/test/XmlBeautify.test.js
@@ -206,7 +206,21 @@ describe('XmlBeautify', () => {
 </object>
 `);
     });
-  });
+    test('Attribute value containing quotes', () => {
+      const srcXmlText = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+  <object>
+  <foo bar="&quot;baz&quot;"></foo></object>`;
+      const beautifiedXmlText = new XmlBeautify({ parser: DOMParser }).beautify(srcXmlText, {
+        useSelfClosingElement: false,
+        
+      });
+      expect(beautifiedXmlText).toBe(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<object>
+  <foo bar="&quot;baz&quot;"></foo>
+</object>
+`);
+    });
 
+  });
 
 });


### PR DESCRIPTION
Double quotes in attribute values need to be escaped as per https://www.w3.org/TR/xml11/#syntax